### PR TITLE
Set up auth for hubspot client.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -21,11 +21,7 @@ import Config
 #     config :logger, level: :info
 #
 config :hubspotex, base_url: "https://api.hubapi.com"
-config :hubspotex, auth_method: "hapikey" # "hapikey" or "token"
-config :hubspotex, auth_key: "demo"
-config :hubspotex, portal_id: "62515"
-config :hubspotex, username: "testapi@hubspot.com"
-config :hubspotex, password: "HubSpot"
+config :hubspotex, access_token: "token"
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/hubspot.ex
+++ b/lib/hubspot.ex
@@ -1,7 +1,15 @@
 defmodule Hubspot do
   alias Hubspot.HTTP.Client
 
+  import Application, only: [get_env: 2]
+
   def request(%Hubspot.HTTP.Request{} = request) do
-    Client.request(request.method, request.endpoint, request.body, [], request.query)
+    Client.request(
+      request.method,
+      request.endpoint,
+      request.body,
+      [Authorization: "Bearer #{get_env(:hubspotex, :access_token)}"],
+      request.query
+    )
   end
 end

--- a/lib/hubspot/deals.ex
+++ b/lib/hubspot/deals.ex
@@ -1,0 +1,23 @@
+defmodule Hubspot.Deals do
+  @doc """
+  Returns a struct that is used in `Hubspot.Client` for
+  getting all deals from Hubspot.
+
+  ## Examples
+      iex> Hubspot.Deals.all()
+      %Hubspot.HTTP.Request{endpoint: "/crm/v3/objects/deals",
+        method: :get, query: [], body: ""}
+
+      iex> Hubspot.Contacts.all([count: 10, vidOffset: 100])
+      %Hubspot.HTTP.Request{endpoint: "/crm/v3/objects/deals",
+        method: :get, query: [count: 10, vidOffset: 100], body: ""}
+  """
+  @spec all(list) :: %Hubspot.HTTP.Request{}
+  def all(params \\ []) do
+    %Hubspot.HTTP.Request{
+      endpoint: "/crm/v3/objects/deals",
+      method: :get,
+      query: params
+    }
+  end
+end

--- a/lib/hubspot/http/client.ex
+++ b/lib/hubspot/http/client.ex
@@ -23,12 +23,8 @@ defmodule Hubspot.HTTP.Client do
           request(:post, "https://my.website.com", "{\"foo\": 3}", [{"Accept", "application/json"}])
   """
   def request(method, url, body \\ "", headers \\ [], params \\ []) do
-    options = params |> add_auth |> process_request_options
+    options = params |> process_request_options
     super(method, url, body, headers, options)
-  end
-
-  defp add_auth(query) do
-    [{get_env(:hubspotex, :auth_method), get_env(:hubspotex, :auth_key)} | query]
   end
 
   def process_url(url = "http" <> _), do: url


### PR DESCRIPTION
This change makes the hubspot client work!

The main change was using bearer access tokens for authentication.  I have created a private hubspot app and have added the access token to onepass.   I also added a basic "deals" file for working with hubspot deals.